### PR TITLE
카테고리별 상품 조회 및 최근 검색어 조회 API구현

### DIFF
--- a/src/main/java/com/example/finance7/member/controller/MemberInfoController.java
+++ b/src/main/java/com/example/finance7/member/controller/MemberInfoController.java
@@ -3,6 +3,7 @@ package com.example.finance7.member.controller;
 import com.example.finance7.member.dto.SomeMemberUpdateInfoRequest;
 import com.example.finance7.member.dto.StatusResponse;
 import com.example.finance7.member.service.MemberInfoService;
+import com.example.finance7.member.vo.MemberSearchHistoryResponseVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -34,5 +35,10 @@ public class MemberInfoController {
     @PatchMapping("user")
     public StatusResponse updateSomeMemberInfo(@RequestBody SomeMemberUpdateInfoRequest memberUpdateInfoRequest) {
         return memberInfoService.updateSomeMemberInfo(memberUpdateInfoRequest.toDto());
+    }
+
+    @GetMapping("user/keywords")
+    public MemberSearchHistoryResponseVO selectRecentSearchKeyWords () {
+        return memberInfoService.selectRecentSearchKeyWords();
     }
 }

--- a/src/main/java/com/example/finance7/member/dto/MemberSearchHistoryResponseDTO.java
+++ b/src/main/java/com/example/finance7/member/dto/MemberSearchHistoryResponseDTO.java
@@ -1,0 +1,15 @@
+package com.example.finance7.member.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class MemberSearchHistoryResponseDTO {
+
+    private Long searchId;
+    private String searchContent;
+    private String createdAt;
+}

--- a/src/main/java/com/example/finance7/member/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/example/finance7/member/repository/SearchHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.example.finance7.member.repository;
+
+import com.example.finance7.member.entity.SearchHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+
+    List<SearchHistory> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/example/finance7/member/service/MemberInfoService.java
+++ b/src/main/java/com/example/finance7/member/service/MemberInfoService.java
@@ -3,6 +3,7 @@ package com.example.finance7.member.service;
 import com.example.finance7.member.dto.SomeMemberUpdateInfoDto;
 import com.example.finance7.member.dto.StatusResponse;
 import com.example.finance7.member.entity.Member;
+import com.example.finance7.member.vo.MemberSearchHistoryResponseVO;
 
 import java.util.Date;
 
@@ -16,4 +17,6 @@ public interface MemberInfoService {
     int calculateAge(Date birthday);
 
     StatusResponse makeStatusResponse(String status);
+
+    MemberSearchHistoryResponseVO selectRecentSearchKeyWords();
 }

--- a/src/main/java/com/example/finance7/member/service/impl/MemberInfoServiceImpl.java
+++ b/src/main/java/com/example/finance7/member/service/impl/MemberInfoServiceImpl.java
@@ -1,19 +1,22 @@
 package com.example.finance7.member.service.impl;
 
+import com.example.finance7.member.dto.MemberSearchHistoryResponseDTO;
 import com.example.finance7.member.dto.SomeMemberUpdateInfoDto;
 import com.example.finance7.member.dto.StatusResponse;
 import com.example.finance7.member.entity.Member;
+import com.example.finance7.member.entity.Scession;
+import com.example.finance7.member.entity.SearchHistory;
 import com.example.finance7.member.repository.MemberRepository;
+import com.example.finance7.member.repository.SearchHistoryRepository;
 import com.example.finance7.member.service.MemberInfoService;
 import com.example.finance7.member.service.MemberService;
+import com.example.finance7.member.vo.MemberSearchHistoryResponseVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import java.util.Calendar;
-import java.util.Date;
-import java.util.NoSuchElementException;
+import java.util.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ public class MemberInfoServiceImpl implements MemberInfoService {
 
     private final MemberRepository memberRepository;
     private final MemberServiceImpl memberService;
+    private final SearchHistoryRepository searchHistoryRepository;
 
     /**
      *전체 회원정보를 조회한다.
@@ -118,5 +122,45 @@ public class MemberInfoServiceImpl implements MemberInfoService {
         return StatusResponse.builder()
                 .status(status)
                 .build();
+    }
+
+    /**
+     * 해당 멤버가 최근 검색한 내역 모두 출력하는 메서드
+     * @return
+     */
+    @Override
+    public MemberSearchHistoryResponseVO selectRecentSearchKeyWords() {
+
+        try {
+            Member member = memberRepository.findById(1L).orElseThrow(
+                    () -> new NoSuchElementException("존재하지 않는 회원입니다.")
+            );
+            if (member.getSecession().equals(Scession.CLOSE)) {
+                throw new RuntimeException("탈되한 회원입니다.");
+            }
+            Long memberId = member.getMemberId();
+            List<SearchHistory> searchHistoryAllByMemberId = searchHistoryRepository.findAllByMemberId(memberId);
+            List<MemberSearchHistoryResponseDTO> memberSearchHistoryResponseDTOList = new ArrayList<>();
+            for (SearchHistory searchHistory : searchHistoryAllByMemberId) {
+                MemberSearchHistoryResponseDTO memberSearchHistoryResponseDTO = MemberSearchHistoryResponseDTO.builder()
+                        .searchId(searchHistory.getHistoryId())
+                        .searchContent(searchHistory.getSearchContent())
+                        .createdAt(searchHistory.getRegisterDate().toString())
+                        .build();
+                memberSearchHistoryResponseDTOList.add(memberSearchHistoryResponseDTO);
+            }
+            return MemberSearchHistoryResponseVO.builder()
+                    .status("success")
+                    .dataNum(memberSearchHistoryResponseDTOList.size())
+                    .resultData(memberSearchHistoryResponseDTOList)
+                    .build();
+
+        }catch (RuntimeException e) {
+
+            return MemberSearchHistoryResponseVO.builder()
+                    .status("failed" + e.getMessage())
+                    .build();
+        }
+
     }
 }

--- a/src/main/java/com/example/finance7/member/vo/MemberSearchHistoryResponseVO.java
+++ b/src/main/java/com/example/finance7/member/vo/MemberSearchHistoryResponseVO.java
@@ -1,0 +1,18 @@
+package com.example.finance7.member.vo;
+
+import com.example.finance7.member.dto.MemberSearchHistoryResponseDTO;
+import lombok.*;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class MemberSearchHistoryResponseVO {
+
+    private String status;
+    private Integer dataNum;
+    private List<MemberSearchHistoryResponseDTO> resultData;
+}

--- a/src/main/java/com/example/finance7/product/controller/ProductController.java
+++ b/src/main/java/com/example/finance7/product/controller/ProductController.java
@@ -4,14 +4,12 @@ import com.example.finance7.product.service.ProductService;
 import com.example.finance7.product.vo.ProductResponsePagingVO;
 import com.example.finance7.product.vo.ProductResponseVO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,9 +27,9 @@ public class ProductController {
         return productService.recommendationProductsList(tagString);
     }
 
-    @GetMapping("/items/all")
-    public ProductResponseVO groupByCategory(String category, @PageableDefault(size = 5) Pageable pageable) {
-        return productService.categoryList(pageable, category);
+    @GetMapping("/items/all/{tagString}")
+    public ProductResponsePagingVO groupByCategory(String category,int page, @PathVariable String tagString) {
+        return productService.categoryList(category, page,tagString);
     }
 
     @GetMapping("/search")

--- a/src/main/java/com/example/finance7/product/controller/ProductController.java
+++ b/src/main/java/com/example/finance7/product/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.example.finance7.product.controller;
 
 import com.example.finance7.product.service.ProductService;
 import com.example.finance7.product.vo.ProductResponsePagingVO;
+import com.example.finance7.product.vo.ProductResponseRecommendationGroupByCategory;
 import com.example.finance7.product.vo.ProductResponseVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -23,7 +24,7 @@ public class ProductController {
     }
 
     @GetMapping("/Recommendation/{tagString}")
-    public ProductResponseVO recommendationProduct(@PathVariable String tagString) {
+    public ProductResponseRecommendationGroupByCategory recommendationProduct(@PathVariable String tagString) {
         return productService.recommendationProductsList(tagString);
     }
 

--- a/src/main/java/com/example/finance7/product/dto/ProductResponseDTO.java
+++ b/src/main/java/com/example/finance7/product/dto/ProductResponseDTO.java
@@ -25,7 +25,7 @@ public class ProductResponseDTO {
 
         if (product instanceof Card){
             return CardResponseDTO.builder()
-                    .category("CARD")
+                    .category("card")
                     .productId(product.getProductId())
                     .productName(product.getProductName())
                     .companyName(product.getCompanyName())
@@ -37,7 +37,7 @@ public class ProductResponseDTO {
 
         } else if (product instanceof Loan) {
             return LoanResponseDTO.builder()
-                    .category("LOAN")
+                    .category("loan")
                     .productId(product.getProductId())
                     .productName(product.getProductName())
                     .companyName(product.getCompanyName())
@@ -52,7 +52,7 @@ public class ProductResponseDTO {
         } else if (product instanceof Savings) {
 
             return SavingResponseDTO.builder()
-                    .category("SAVINGS")
+                    .category("savings")
                     .productId(product.getProductId())
                     .productName(product.getProductName())
                     .companyName(product.getCompanyName())
@@ -67,7 +67,7 @@ public class ProductResponseDTO {
             Subscription subscription = (Subscription) product;
             return SubscriptionResponseDTO.builder()
                     .productId(product.getProductId())
-                    .category("SUBSCRIPTION")
+                    .category("subscription")
                     .productName(product.getProductName())
                     .companyName(product.getCompanyName())
                     .companyImage(product.getCompanyImage())

--- a/src/main/java/com/example/finance7/product/repository/CardRepository.java
+++ b/src/main/java/com/example/finance7/product/repository/CardRepository.java
@@ -3,10 +3,21 @@ package com.example.finance7.product.repository;
 import com.example.finance7.product.entity.Card;
 import com.example.finance7.product.entity.Product;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CardRepository extends JpaRepository<Card, Long> {
 
     Page<Product> findAllByProductNameContaining(String productName, Pageable pageable);
+
+    Page<Product> findAllByTagsContaining(String tags,
+                                          PageRequest pageRequest);
+    Page<Product> findAllByTagsContainingOrTagsContaining(String tags1,
+                                                          String tags2,
+                                                          PageRequest pageRequest);
+    Page<Product> findAllByTagsContainingOrTagsContainingOrTagsContaining(String tags1,
+                                                                          String tags2,
+                                                                          String tags3,
+                                                                          PageRequest pageRequest);
 }

--- a/src/main/java/com/example/finance7/product/repository/LoanRepository.java
+++ b/src/main/java/com/example/finance7/product/repository/LoanRepository.java
@@ -3,10 +3,21 @@ package com.example.finance7.product.repository;
 import com.example.finance7.product.entity.Loan;
 import com.example.finance7.product.entity.Product;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LoanRepository extends JpaRepository<Loan, Long> {
 
     Page<Product> findAllByProductNameContaining(String productName, Pageable pageable);
+
+    Page<Product> findAllByTagsContaining(String tags,
+                                          PageRequest pageRequest);
+    Page<Product> findAllByTagsContainingOrTagsContaining(String tags1,
+                                                          String tags2,
+                                                          PageRequest pageRequest);
+    Page<Product> findAllByTagsContainingOrTagsContainingOrTagsContaining(String tags1,
+                                                                          String tags2,
+                                                                          String tags3,
+                                                                          PageRequest pageRequest);
 }

--- a/src/main/java/com/example/finance7/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/finance7/product/repository/ProductRepository.java
@@ -2,6 +2,7 @@ package com.example.finance7.product.repository;
 
 import com.example.finance7.product.entity.Product;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,14 @@ import org.springframework.stereotype.Repository;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Page<Product> findAllByProductNameContaining(String productName, Pageable pageable);
+    Page<Product> findAllByTagsContaining(String tags,
+                                          PageRequest pageRequest);
+    Page<Product> findAllByTagsContainingOrTagsContaining(String tags1,
+                                                          String tags2,
+                                                          PageRequest pageRequest);
+    Page<Product> findAllByTagsContainingOrTagsContainingOrTagsContaining(String tags1,
+                                                                          String tags2,
+                                                                          String tags3,
+                                                                          PageRequest pageRequest);
+
 }

--- a/src/main/java/com/example/finance7/product/repository/SavingsRepository.java
+++ b/src/main/java/com/example/finance7/product/repository/SavingsRepository.java
@@ -3,10 +3,21 @@ package com.example.finance7.product.repository;
 import com.example.finance7.product.entity.Product;
 import com.example.finance7.product.entity.Savings;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SavingsRepository extends JpaRepository<Savings, Long> {
 
     Page<Product> findAllByProductNameContaining(String productName, Pageable pageable);
+
+    Page<Product> findAllByTagsContaining(String tags,
+                                          PageRequest pageRequest);
+    Page<Product> findAllByTagsContainingOrTagsContaining(String tags1,
+                                                          String tags2,
+                                                          PageRequest pageRequest);
+    Page<Product> findAllByTagsContainingOrTagsContainingOrTagsContaining(String tags1,
+                                                                          String tags2,
+                                                                          String tags3,
+                                                                          PageRequest pageRequest);
 }

--- a/src/main/java/com/example/finance7/product/repository/SubscriptionRepository.java
+++ b/src/main/java/com/example/finance7/product/repository/SubscriptionRepository.java
@@ -3,10 +3,21 @@ package com.example.finance7.product.repository;
 import com.example.finance7.product.entity.Product;
 import com.example.finance7.product.entity.Subscription;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
 
     Page<Product> findAllByProductNameContaining(String productName, Pageable pageable);
+
+    Page<Product> findAllByTagsContaining(String tags,
+                                          PageRequest pageRequest);
+    Page<Product> findAllByTagsContainingOrTagsContaining(String tags1,
+                                                          String tags2,
+                                                          PageRequest pageRequest);
+    Page<Product> findAllByTagsContainingOrTagsContainingOrTagsContaining(String tags1,
+                                                                          String tags2,
+                                                                          String tags3,
+                                                                          PageRequest pageRequest);
 }

--- a/src/main/java/com/example/finance7/product/service/ProductService.java
+++ b/src/main/java/com/example/finance7/product/service/ProductService.java
@@ -1,7 +1,8 @@
-package com.example.finance7.product.repository.service;
+package com.example.finance7.product.service;
 
 import com.example.finance7.product.entity.Product;
 import com.example.finance7.product.vo.ProductResponsePagingVO;
+import com.example.finance7.product.vo.ProductResponseRecommendationGroupByCategory;
 import com.example.finance7.product.vo.ProductResponseVO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,7 +27,7 @@ public interface ProductService {
      * @param tagString
      * @return
      */
-    public ProductResponseVO recommendationProductsList(String tagString);
+    public ProductResponseRecommendationGroupByCategory recommendationProductsList(String tagString);
 
     /**
      * 카테고리별 태그 조회

--- a/src/main/java/com/example/finance7/product/service/ProductService.java
+++ b/src/main/java/com/example/finance7/product/service/ProductService.java
@@ -29,11 +29,13 @@ public interface ProductService {
     public ProductResponseVO recommendationProductsList(String tagString);
 
     /**
-     * 카테고리별 상품 조회
-     * @param pageable
+     * 카테고리별 태그 조회
+     * @param category
+     * @param page
+     * @param tagString
      * @return
      */
-    public ProductResponseVO categoryList(Pageable pageable, String category);
+    public ProductResponsePagingVO categoryList(String category, int page, String tagString);
 
     /**
      * 카테고리별 검색결과 조회

--- a/src/main/java/com/example/finance7/product/service/ProductService.java
+++ b/src/main/java/com/example/finance7/product/service/ProductService.java
@@ -1,4 +1,4 @@
-package com.example.finance7.product.service;
+package com.example.finance7.product.repository.service;
 
 import com.example.finance7.product.entity.Product;
 import com.example.finance7.product.vo.ProductResponsePagingVO;

--- a/src/main/java/com/example/finance7/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/example/finance7/product/service/impl/ProductServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.finance7.product.vo.ProductResponsePagingVO;
 import com.example.finance7.product.vo.ProductResponseVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ import java.util.*;
 @RequiredArgsConstructor
 public class ProductServiceImpl implements ProductService {
 
+    private final int SIZE = 5;
     private final ProductRepository productRepository;
     private final CardRepository cardRepository;
     private final LoanRepository loanRepository;
@@ -113,12 +115,163 @@ public class ProductServiceImpl implements ProductService {
 
     /**
      * 카테고리별 상품 조회
-     * @param pageable
+     * @param page
      * @return
      */
     @Override
-    public ProductResponseVO categoryList(Pageable pageable, String category) {
-        return null;
+    public ProductResponsePagingVO categoryList(String category, int page, String tagString) {
+        PageRequest pageRequest = PageRequest.of(page - 1, SIZE);
+        String[] tags = tagString.split("&");
+        List<ProductResponseDTO> productResponseDTOList = new ArrayList<>();
+        int totalPage = 0;
+
+        if (category == null || category.equals("")){
+            if(tags.length == 1){
+                Page<Product> allByTagsContaining = productRepository.findAllByTagsContaining(tags[0], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }else if(tags.length == 2){
+                Page<Product> allByTagsContaining = productRepository.findAllByTagsContainingOrTagsContaining(tags[0], tags[1], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }else {
+                Page<Product> allByTagsContaining = productRepository.findAllByTagsContainingOrTagsContainingOrTagsContaining(tags[0], tags[1], tags[2], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }
+        }else if (category.equals("card")) {
+            if(tags.length == 1){
+                Page<Product> allByTagsContaining = cardRepository.findAllByTagsContaining(tags[0], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }else if(tags.length == 2){
+                Page<Product> allByTagsContaining = cardRepository.findAllByTagsContainingOrTagsContaining(tags[0], tags[1], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }else {
+                Page<Product> allByTagsContaining = cardRepository.findAllByTagsContainingOrTagsContainingOrTagsContaining(tags[0], tags[1], tags[2], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }
+
+        }else if (category.equals("loan")) {
+            if(tags.length == 1){
+                Page<Product> allByTagsContaining = loanRepository.findAllByTagsContaining(tags[0], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }else if(tags.length == 2){
+                Page<Product> allByTagsContaining = loanRepository.findAllByTagsContainingOrTagsContaining(tags[0], tags[1], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }else {
+                Page<Product> allByTagsContaining = loanRepository.findAllByTagsContainingOrTagsContainingOrTagsContaining(tags[0], tags[1], tags[2], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }
+
+        }else if (category.equals("savings")) {
+            if(tags.length == 1){
+                Page<Product> allByTagsContaining = savingsRepository.findAllByTagsContaining(tags[0], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }else if(tags.length == 2){
+                Page<Product> allByTagsContaining = savingsRepository.findAllByTagsContainingOrTagsContaining(tags[0], tags[1], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }else {
+                Page<Product> allByTagsContaining = savingsRepository.findAllByTagsContainingOrTagsContainingOrTagsContaining(tags[0], tags[1], tags[2], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }
+
+        }else if (category.equals("subscription")) {
+            if(tags.length == 1){
+                Page<Product> allByTagsContaining = subscriptionRepository.findAllByTagsContaining(tags[0], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }else if(tags.length == 2){
+                Page<Product> allByTagsContaining = subscriptionRepository.findAllByTagsContainingOrTagsContaining(tags[0], tags[1], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }else {
+                Page<Product> allByTagsContaining = subscriptionRepository.findAllByTagsContainingOrTagsContainingOrTagsContaining(tags[0], tags[1], tags[2], pageRequest);
+                totalPage = allByTagsContaining.getTotalPages();
+                for (Product product : allByTagsContaining) {
+                    ProductResponseDTO productResponseDTO = new ProductResponseDTO().toDTO(product);
+                    productResponseDTOList.add(productResponseDTO);
+                }
+            }
+
+        }
+        return getProductResponsePagingVO(page, productResponseDTOList, totalPage);
+    }
+
+    /**
+     * 데이터 결과가 있는지 없는지 반환 데이터 판별 메서드
+     * @param page
+     * @param productResponseDTOList
+     * @param totalPage
+     * @return
+     */
+    private ProductResponsePagingVO getProductResponsePagingVO(int page, List<ProductResponseDTO> productResponseDTOList, int totalPage) {
+        if(productResponseDTOList.size() == 0){
+            return ProductResponsePagingVO.builder()
+                    .dataNum(0)
+                    .status("failed 검색결과가 없습니다.")
+                    .build();
+
+        }else {
+            return ProductResponsePagingVO.builder()
+                    .dataNum(productResponseDTOList.size())
+                    .status("success")
+                    .currentPage(page)
+                    .totalPage(totalPage)
+                    .resultData(productResponseDTOList)
+                    .build();
+
+        }
     }
 
     /**

--- a/src/main/java/com/example/finance7/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/example/finance7/product/service/impl/ProductServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.finance7.product.entity.*;
 import com.example.finance7.product.repository.*;
 import com.example.finance7.product.service.ProductService;
 import com.example.finance7.product.vo.ProductResponsePagingVO;
+import com.example.finance7.product.vo.ProductResponseRecommendationGroupByCategory;
 import com.example.finance7.product.vo.ProductResponseVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -74,22 +75,39 @@ public class ProductServiceImpl implements ProductService {
      * @return
      */
     @Override
-    public ProductResponseVO recommendationProductsList(String tagString) {
+    public ProductResponseRecommendationGroupByCategory recommendationProductsList(String tagString) {
         List<Product> products = productRepository.findAll();
 
         String[] tags = tagString.split("&");
         Map<Long, ProductResponseDTO> deduplication = deduplication(products, tags);
         List<ProductResponseDTO> result = new ArrayList<>(deduplication.values());
+        List<CardResponseDTO> card = new ArrayList<>();
+        List<LoanResponseDTO> loan = new ArrayList<>();
+        List<SavingResponseDTO> savings = new ArrayList<>();
+        List<SubscriptionResponseDTO> subscription = new ArrayList<>();
+
+        for (ProductResponseDTO productResponseDTO : result) {
+            if(productResponseDTO instanceof CardResponseDTO){
+                card.add((CardResponseDTO) productResponseDTO);
+            }else if(productResponseDTO instanceof LoanResponseDTO){
+                loan.add((LoanResponseDTO) productResponseDTO);
+            }else if (productResponseDTO instanceof SavingResponseDTO) {
+                savings.add((SavingResponseDTO) productResponseDTO);
+            }else {
+                subscription.add((SubscriptionResponseDTO) productResponseDTO);
+            }
+        }
         if (result.size() == 0){
-            return ProductResponseVO.builder()
-                    .dataNum(0)
+            return ProductResponseRecommendationGroupByCategory.builder()
                     .status("failed 검색결과가 없습니다.")
                     .build();
         } else {
-            return ProductResponseVO.builder()
-                    .dataNum(result.size())
+            return ProductResponseRecommendationGroupByCategory.builder()
                     .status("success")
-                    .resultData(result)
+                    .card(card)
+                    .loan(loan)
+                    .savings(savings)
+                    .subscription(subscription)
                     .build();
         }
     }

--- a/src/main/java/com/example/finance7/product/vo/ProductResponseRecommendationGroupByCategory.java
+++ b/src/main/java/com/example/finance7/product/vo/ProductResponseRecommendationGroupByCategory.java
@@ -1,0 +1,23 @@
+package com.example.finance7.product.vo;
+
+import com.example.finance7.product.dto.CardResponseDTO;
+import com.example.finance7.product.dto.LoanResponseDTO;
+import com.example.finance7.product.dto.SavingResponseDTO;
+import com.example.finance7.product.dto.SubscriptionResponseDTO;
+import lombok.*;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ProductResponseRecommendationGroupByCategory {
+
+    private String status;
+    private List<CardResponseDTO> card;
+    private List<LoanResponseDTO> loan;
+    private List<SavingResponseDTO> savings;
+    private List<SubscriptionResponseDTO> subscription;
+}

--- a/src/test/java/com/example/finance7/member/service/impl/MemberInfoServiceImplTest.java
+++ b/src/test/java/com/example/finance7/member/service/impl/MemberInfoServiceImplTest.java
@@ -1,0 +1,47 @@
+package com.example.finance7.member.service.impl;
+
+import com.example.finance7.member.entity.Member;
+import com.example.finance7.member.entity.SearchHistory;
+import com.example.finance7.member.repository.MemberRepository;
+import com.example.finance7.member.repository.SearchHistoryRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@SpringBootTest
+class MemberInfoServiceImplTest {
+
+    @Autowired
+    SearchHistoryRepository searchHistoryRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Transactional
+    @Test
+    void 검색_조회_결과_테스트() {
+        //given
+        Member member = memberRepository.findById(1L).get();
+        SearchHistory 주택 = SearchHistory.builder()
+                .memberId(1L)
+                .registerDate(LocalDateTime.now())
+                .searchContent("주택")
+                .build();
+        SearchHistory 청년 = SearchHistory.builder()
+                .memberId(1L)
+                .registerDate(LocalDateTime.now())
+                .searchContent("청년")
+                .build();
+
+        searchHistoryRepository.save(청년);
+        searchHistoryRepository.save(주택);
+        //when
+        List<SearchHistory> searchHistories = searchHistoryRepository.findAllByMemberId(member.getMemberId());
+        //then
+        Assertions.assertThat(searchHistories.size()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## Motivation

- 카테고리별 태그가 최대3개까지 선택 가능한 서비스 구현했습니다.(product)
- 최근 검색어 조회 서비스 구현했습니다.(member)
- 태그별 추천 상품 카테고리별로 분류되도록 수정했습니다.(product)

<!-- 작업한 내용에 대한 설명 
- 객체들의 연관관계를 기준으로 Entity를 설계했습니다.
- 도메인 별로 Repository를 생성했습니다.
-->
    

## Key Changes

- 카테고리별 태그가 최대 3개까지 선택 가능한 서비스를 구현했습니다.(product)
- 한페이지에 5개씩 반환하도록 페이징도 했습니다.(product)
- 최근 검색어 반환하는 서비스를 구현했습니다.(member)
- 기존에 카테고리별로 분류안되던 추천상품 조회 API를 카테고리별로 분류해서 반환하도록 수정했습니다.(product)

<!-- 작업한 내용의 주요 변경 사항에 대한 나열
  - Post Entity 설계를 완료했습니다.
    - 기간은 Embedded 타입으로 설계했습니다.
  - 변경 2
  - 변경 3
-->

## To reviewers
메서드가 100줄이 넘어가는데 일단 구현을 빨리해야 하니 풀리퀘스트 올려봅니다.
어제 올렸던 풀리퀘스트가 아직 merge가 되지 않아서 오늘 만든거랑 합쳐졌네요

<!-- 이 PR을 확인할 Code Reviewer에게 남길 메시지
- 객체 연관관계가 잘 고려되었는지를 중점적으로 봐주세요
-->
