### PR TITLE
fix: 중복 검색어 추가 시 제일 위로 오도록 변경

### DIFF
--- a/src/main/java/com/example/finance7/member/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/example/finance7/member/repository/SearchHistoryRepository.java
@@ -26,4 +26,8 @@ public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Lo
     @Query("delete from SearchHistory s where s.memberId = :memberId")
     int deleteByMemberId(@Param("memberId") Long memberId);
 
+
+    @Modifying
+    void deleteSearchHistoryByMemberIdAndSearchContent(Long memberId, String searchContent);
+
 }

--- a/src/main/java/com/example/finance7/member/service/impl/MemberInfoServiceImpl.java
+++ b/src/main/java/com/example/finance7/member/service/impl/MemberInfoServiceImpl.java
@@ -155,7 +155,15 @@ public class MemberInfoServiceImpl implements MemberInfoService {
                         .status("success")
                         .build();
             } else {
-                throw new Exception();
+                searchHistoryRepository.deleteSearchHistoryByMemberIdAndSearchContent(member.getMemberId(), keyword);
+                SearchHistory searchHistory = SearchHistory.builder()
+                        .memberId(member.getMemberId())
+                        .searchContent(keyword)
+                        .build();
+                searchHistoryRepository.save(searchHistory);
+                return StatusResponseDTO.builder()
+                        .status("success")
+                        .build();
             }
         } catch (Exception e) {
             return StatusResponseDTO.builder()


### PR DESCRIPTION
## Motivation

<!-- 작업한 대용에 대한 설명 
- 객체들의 연관관계를 기준으로 Entity를 설계했습니다.
- 도메인 별로 Repository를 생성했습니다.
-->
- 중복 검색어 추가시 발생하는 로직이 변경되었습니다.    

## Key Changes

<!-- 작업한 내용의 주요 변경 사항에 대한 나열
  - Post Entity 설계를 완료했습니다.
    - 기간은 Embedded 타입으로 설계했습니다.
  - 변경 2
  - 변경 3
-->
- 1b514b20759abba4b6b5dc287ecf0ec67fb2a1a9 중복 검색어 추가시 최근에 검색한 검색어가 가장 위로 가도록 변경했습니다.
## To reviewers
- 오늘 마감입니다 와아아아
<!-- 이 PR을 확인할 Code Reviewer에게 남길 메시지
- 객체 연관관계가 잘 고려되었는지를 중점적으로 봐주세요
-->
